### PR TITLE
add zesty to list of supported Ubuntu versions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
+        - zesty
     - name: Debian
       versions:
         - jessie


### PR DESCRIPTION
Successfully tested with zesty (Ubuntu 17.04)